### PR TITLE
Fix installation commands for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,25 +31,25 @@ curl -s https://get.codex.storage/install.sh | bash -s help
 
 ```batch
 :: latest version
-curl -s https://get.codex.storage/install.cmd && install.cmd
+curl -sO https://get.codex.storage/install.cmd && install.cmd
 ```
 
 ```batch
 :: specific version
-curl -s https://get.codex.storage/install.cmd && set VERSION=0.1.7 & install.cmd
+curl -sO https://get.codex.storage/install.cmd && set VERSION=0.1.7 & install.cmd
 ```
 
 ```batch
 :: latest codex and cirdl
-curl -s https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true & install.cmd
+curl -sO https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true & install.cmd
 ```
 
 ```batch
 :: codex and cirdl without libraries
-curl -s https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true & set WINDOWS_LIBS=true & install.cmd
+curl -sO https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true & set WINDOWS_LIBS=true & install.cmd
 ```
 
 ```batch
 :: help
-curl -s https://get.codex.storage/install.cmd && install.cmd help
+curl -sO https://get.codex.storage/install.cmd && install.cmd help
 ```

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
     <body>
         <h3>
-                Get Codex - Linux/macOS
+                Get Codex - Linux, macOS and Windows (msys2)
         </h3>
 
         <p>
@@ -58,7 +58,7 @@
             # latest version
         </span>
         <br>
-            curl -s https://get.codex.storage/install.cmd && install.cmd
+            curl -sO https://get.codex.storage/install.cmd && install.cmd
     </p>
 
     <p>
@@ -66,7 +66,7 @@
             # specific version
         </span>
         <br>
-            curl -s https://get.codex.storage/install.cmd && set VERSION=0.1.7 & install.cmd
+            curl -sO https://get.codex.storage/install.cmd && set VERSION=0.1.7 & install.cmd
     </p>
 
     <p>
@@ -74,7 +74,7 @@
             # latest codex and cirdl
         </span>
         <br>
-            curl -s https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true install.cmd
+            curl -sO https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true install.cmd
     </p>
 
     <p>
@@ -82,7 +82,7 @@
             # codex and cirdl without libraries
         </span>
         <br>
-            curl -s https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true & set WINDOWS_LIBS=false & install.cmd
+            curl -sO https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true & set WINDOWS_LIBS=false & install.cmd
     </p>
     </body>
 </html>


### PR DESCRIPTION
This is a #7 follow up and it fixes installation commands for Windows in Readme and index files.