### PR TITLE
Use native Windows comments in index file

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
 
     <p>
         <span style="color:grey;">
-            # latest version
+            :: latest version
         </span>
         <br>
             curl -sO https://get.codex.storage/install.cmd && install.cmd
@@ -63,7 +63,7 @@
 
     <p>
         <span style="color:grey;">
-            # specific version
+            :: specific version
         </span>
         <br>
             curl -sO https://get.codex.storage/install.cmd && set VERSION=0.1.7 & install.cmd
@@ -71,7 +71,7 @@
 
     <p>
         <span style="color:grey;">
-            # latest codex and cirdl
+            :: latest codex and cirdl
         </span>
         <br>
             curl -sO https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true install.cmd
@@ -79,7 +79,7 @@
 
     <p>
         <span style="color:grey;">
-            # codex and cirdl without libraries
+            :: codex and cirdl without libraries
         </span>
         <br>
             curl -sO https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true & set WINDOWS_LIBS=false & install.cmd


### PR DESCRIPTION
Cosmetic changes for index file to use native Windows comments - `::`, instead of the shell ones - `#`.