### PR TITLE
Fix index file indentations

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,41 +48,43 @@
             <br>
                 curl -s https://get.codex.storage/install.sh | INSTALL_CIRDL=true WINDOWS_LIBS=true bash
         </p>
+
         <br>
+
         <h3>
             Get Codex - Windows
-    </h3>
+        </h3>
 
-    <p>
-        <span style="color:grey;">
-            :: latest version
-        </span>
-        <br>
-            curl -sO https://get.codex.storage/install.cmd && install.cmd
-    </p>
+        <p>
+            <span style="color:grey;">
+                :: latest version
+            </span>
+            <br>
+                curl -sO https://get.codex.storage/install.cmd && install.cmd
+        </p>
 
-    <p>
-        <span style="color:grey;">
-            :: specific version
-        </span>
-        <br>
-            curl -sO https://get.codex.storage/install.cmd && set VERSION=0.1.7 & install.cmd
-    </p>
+        <p>
+            <span style="color:grey;">
+                :: specific version
+            </span>
+            <br>
+                curl -sO https://get.codex.storage/install.cmd && set VERSION=0.1.7 & install.cmd
+        </p>
 
-    <p>
-        <span style="color:grey;">
-            :: latest codex and cirdl
-        </span>
-        <br>
-            curl -sO https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true install.cmd
-    </p>
+        <p>
+            <span style="color:grey;">
+                :: latest codex and cirdl
+            </span>
+            <br>
+                curl -sO https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true install.cmd
+        </p>
 
-    <p>
-        <span style="color:grey;">
-            :: codex and cirdl without libraries
-        </span>
-        <br>
-            curl -sO https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true & set WINDOWS_LIBS=false & install.cmd
-    </p>
+        <p>
+            <span style="color:grey;">
+                :: codex and cirdl without libraries
+            </span>
+            <br>
+                curl -sO https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true & set WINDOWS_LIBS=false & install.cmd
+        </p>
     </body>
 </html>


### PR DESCRIPTION
Quick PR to fix index file indentations.

So, now we can get well aligned commands using curl
```shell
curl -sL get.codex.storage | grep curl
```
```
                curl -s https://get.codex.storage/install.sh | bash
                curl -s https://get.codex.storage/install.sh | VERSION=0.1.7 bash
                curl -s https://get.codex.storage/install.sh | INSTALL_CIRDL=true bash
                curl -s https://get.codex.storage/install.sh | INSTALL_CIRDL=true WINDOWS_LIBS=true bash
                curl -sO https://get.codex.storage/install.cmd && install.cmd
                curl -sO https://get.codex.storage/install.cmd && set VERSION=0.1.7 & install.cmd
                curl -sO https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true install.cmd
                curl -sO https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true & set WINDOWS_LIBS=false & install.cmd
```
