### PR TITLE
Improve show_pass function when sudo ask for a password

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,8 @@ show_progress() {
 }
 
 show_pass() {
-  echo -e "\r\e[1A\e[0K ${PASS_MARK} ${1}"
+  echo -e "\r\e[${TRIM:-1}A\e[0K ${PASS_MARK} ${1}"
+  unset TRIM
 }
 
 show_fail() {
@@ -188,6 +189,7 @@ for BINARY in "${BINARIES[@]}"; do
   message="Installing ${FILE_NAME} to ${INSTALL_PATH}"
   show_progress "${message}"
   if ! (mkdir -p "${INSTALL_DIR}" && install -m 755 "${TEMP_DIR}/${FILE_NAME}" "${INSTALL_PATH}") 2> /dev/null; then
+    $(sudo -n true 2>/dev/null) || TRIM=2
     sudo mkdir -p "${INSTALL_DIR}" && sudo install -m 755 "${TEMP_DIR}/${FILE_NAME}" "${INSTALL_PATH}"
     [[ $? -ne 0 ]] && show_fail "${message}"
   fi


### PR DESCRIPTION
We've improved `show_pass` function to trim last 2 lines when `sudo` ask for a password during installation.

However, it will work correctly only when password is asked only once, because at the second attempt we should trim +1 line and this is not handled.