### PR TITLE
Do not show extract progress on Windows when unzip is used

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -167,7 +167,7 @@ for ARCHIVE in "${ARCHIVES[@]}"; do
 
   if [[ "${OS}" == "windows" ]]; then
     if unzip -v &> /dev/null; then
-      unzip -o "${TEMP_DIR}/${FILE_NAME}" -d "${TEMP_DIR}"
+      unzip -q -o "${TEMP_DIR}/${FILE_NAME}" -d "${TEMP_DIR}"
       [[ $? -ne 0 ]] && show_fail "${message}"
     else
       C:/Windows/system32/tar.exe -xzf "${TEMP_DIR}/${FILE_NAME}" -C "${TEMP_DIR}"


### PR DESCRIPTION
Installation script `install.sh` was tested for Windows mostly using the `tar`.

But when we have `unzip`, current configuration will print some output. PR fixes that and we have a clean output with `unzip` as well.