### PR TITLE
Update installation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ curl -s https://get.codex.storage/install.sh | VERSION=0.1.7 bash
 
 ```shell
 # latest codex and cirdl
-curl -s https://get.codex.storage/install.sh | INSTALL_CIRDL=true bash
+curl -s https://get.codex.storage/install.sh | CIRDL=true bash
 ```
 
 ```shell
 # codex and cirdl with required libraries on Windows with msys2
-curl -s https://get.codex.storage/install.sh | INSTALL_CIRDL=true WINDOWS_LIBS=true bash
+curl -s https://get.codex.storage/install.sh | CIRDL=true WINDOWS_LIBS=true bash
 ```
 
 ```shell
@@ -41,12 +41,12 @@ curl -sO https://get.codex.storage/install.cmd && set VERSION=0.1.7 & install.cm
 
 ```batch
 :: latest codex and cirdl
-curl -sO https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true & install.cmd
+curl -sO https://get.codex.storage/install.cmd && set CIRDL=true & install.cmd
 ```
 
 ```batch
 :: codex and cirdl without libraries
-curl -sO https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true & set WINDOWS_LIBS=true & install.cmd
+curl -sO https://get.codex.storage/install.cmd && set CIRDL=true & set WINDOWS_LIBS=true & install.cmd
 ```
 
 ```batch

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
                 # latest codex and cirdl
             </span>
             <br>
-                curl -s https://get.codex.storage/install.sh | INSTALL_CIRDL=true bash
+                curl -s https://get.codex.storage/install.sh | CIRDL=true bash
         </p>
 
         <p>
@@ -46,7 +46,7 @@
                 # codex and cirdl with required libraries on Windows with msys2
             </span>
             <br>
-                curl -s https://get.codex.storage/install.sh | INSTALL_CIRDL=true WINDOWS_LIBS=true bash
+                curl -s https://get.codex.storage/install.sh | CIRDL=true WINDOWS_LIBS=true bash
         </p>
 
         <br>
@@ -76,7 +76,7 @@
                 :: latest codex and cirdl
             </span>
             <br>
-                curl -sO https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true install.cmd
+                curl -sO https://get.codex.storage/install.cmd && set CIRDL=true install.cmd
         </p>
 
         <p>
@@ -84,7 +84,7 @@
                 :: codex and cirdl without libraries
             </span>
             <br>
-                curl -sO https://get.codex.storage/install.cmd && set INSTALL_CIRDL=true & set WINDOWS_LIBS=false & install.cmd
+                curl -sO https://get.codex.storage/install.cmd && set CIRDL=true & set WINDOWS_LIBS=false & install.cmd
         </p>
     </body>
 </html>

--- a/install.cmd
+++ b/install.cmd
@@ -5,7 +5,7 @@ setlocal enabledelayedexpansion
 
 :: Variables
 if not defined VERSION set VERSION=latest
-if not defined INSTALL_CIRDL set INSTALL_CIRDL=false
+if not defined CIRDL set CIRDL=false
 if not defined INSTALL_DIR set "INSTALL_DIR=%LOCALAPPDATA%\Codex"
 set CODEX_ARCHIVE_PREFIX=codex
 set CIRDL_ARCHIVE_PREFIX=cirdl
@@ -26,14 +26,14 @@ if "%1" == "help" (
   set URL=https://get.codex.storage/!SCRIPT_NAME!
   set "COMMAND=curl -sO !URL!"
   echo   !COMMAND! ^&^& !SCRIPT_NAME!
-  echo   !COMMAND! ^&^& set VERSION=0.1.7 ^& set INSTALL_CIRDL=true ^& !SCRIPT_NAME!
+  echo   !COMMAND! ^&^& set VERSION=0.1.7 ^& set CIRDL=true ^& !SCRIPT_NAME!
   echo   !COMMAND! ^&^& set VERSION=0.1.7 ^& set WINDOWS_LIBS=false ^& !SCRIPT_NAME!
   echo   !COMMAND! ^&^& set VERSION=0.1.7 ^& set "INSTALL_DIR=C:\Program Files\Codex" ^& !SCRIPT_NAME!
   echo.
   echo %ESC%[93mOptions:%ESC%[%m
   echo   - help                                 - show this help
   echo   - VERSION=0.1.7                        - codex and cird version to install
-  echo   - INSTALL_CIRDL=true                   - install cirdl
+  echo   - CIRDL=true                           - install cirdl
   echo   - "INSTALL_DIR=C:\Program Files\Codex" - directory to install binaries
   echo   - WINDOWS_LIBS=false                   - download and install archive without the libs
   exit /b 0
@@ -89,9 +89,9 @@ if "%VERSION%" == "latest" (
 set message="Computing archives and binaries names"
 call :show_progress %message%
 ::: Remove trailing spaces
-for /l %%v in (1,1,100) do if "!INSTALL_CIRDL:~-1!"==" " set INSTALL_CIRDL=!INSTALL_CIRDL:~0,-1!
+for /l %%v in (1,1,100) do if "!CIRDL:~-1!"==" " set CIRDL=!CIRDL:~0,-1!
 ::: Set variables
-if "%INSTALL_CIRDL%" == "true" (
+if "%CIRDL%" == "true" (
   set "ARCHIVES=%CODEX_ARCHIVE_PREFIX% %CIRDL_ARCHIVE_PREFIX%"
   set "BINARIES=%CODEX_BINARY_PREFIX% %CIRDL_BINARY_PREFIX%"
 ) else (

--- a/install.cmd
+++ b/install.cmd
@@ -4,17 +4,49 @@ setlocal enabledelayedexpansion
 :: Install Codex on Windows
 
 :: Variables
-if not defined VERSION set VERSION=latest
-if not defined CIRDL set CIRDL=false
-if not defined INSTALL_DIR set "INSTALL_DIR=%LOCALAPPDATA%\Codex"
+if defined VERSION (
+  :: Remove trailing spaces
+  for /l %%v in (1,1,100) do if "!VERSION:~-1!"==" " set VERSION=v!VERSION:~0,-1!
+) else (
+  set VERSION=latest
+)
+
+if defined CIRDL (
+  for /l %%v in (1,1,100) do if "!CIRDL:~-1!"==" " set CIRDL=!CIRDL:~0,-1!
+) else (
+  set CIRDL=false
+)
+
+if defined INSTALL_DIR (
+  for /l %%v in (1,1,100) do if "!INSTALL_DIR:~-1!"==" " set INSTALL_DIR=!INSTALL_DIR:~0,-1!
+) else (
+  set "INSTALL_DIR=%LOCALAPPDATA%\Codex"
+)
+
 set CODEX_ARCHIVE_PREFIX=codex
 set CIRDL_ARCHIVE_PREFIX=cirdl
 set CODEX_BINARY_PREFIX=codex
 set CIRDL_BINARY_PREFIX=cirdl
-if not defined WINDOWS_LIBS set WINDOWS_LIBS=true
-set BASE_URL=https://github.com/codex-storage/nim-codex
+
+if defined WINDOWS_LIBS (
+  for /l %%v in (1,1,100) do if "!WINDOWS_LIBS:~-1!"==" " set WINDOWS_LIBS=!WINDOWS_LIBS:~0,-1!
+) else (
+  set WINDOWS_LIBS=true
+)
+
+if defined BASE_URL (
+  for /l %%v in (1,1,100) do if "!BASE_URL:~-1!"==" " set BASE_URL=!BASE_URL:~0,-1!
+) else (
+  set BASE_URL=https://github.com/codex-storage/nim-codex
+)
+
 set API_BASE_URL=https://api.github.com/repos/codex-storage/nim-codex
-if not defined TEMP_DIR set TEMP_DIR=.
+
+if defined TEMP_DIR (
+  for /l %%v in (1,1,100) do if "!TEMP_DIR:~-1!"==" " set TEMP_DIR=!TEMP_DIR:~0,-1!
+) else (
+  set TEMP_DIR=.
+)
 
 :: Colors
 for /f %%a in ('echo prompt $E^| cmd') do set "ESC=%%a"
@@ -36,6 +68,7 @@ if "%1" == "help" (
   echo   - CIRDL=true                           - install cirdl
   echo   - "INSTALL_DIR=C:\Program Files\Codex" - directory to install binaries
   echo   - WINDOWS_LIBS=false                   - download and install archive without the libs
+  echo   - BASE_URL=http://localhost:8080       - custom base URL for binaries downloading
   exit /b 0
 )
 
@@ -80,16 +113,11 @@ set message="Computing version"
 call :show_progress %message%
 if "%VERSION%" == "latest" (
   for /f delims^=^"^ tokens^=4 %%v in ('curl -Ls %API_BASE_URL%/releases/latest ^| find "tag_name"') do set VERSION=%%v
-) else (
-  ::: Remove trailing spaces
-  for /l %%v in (1,1,100) do if "!VERSION:~-1!"==" " set VERSION=v!VERSION:~0,-1!
 )
 
 :: Archives and binaries
 set message="Computing archives and binaries names"
 call :show_progress %message%
-::: Remove trailing spaces
-for /l %%v in (1,1,100) do if "!CIRDL:~-1!"==" " set CIRDL=!CIRDL:~0,-1!
 ::: Set variables
 if "%CIRDL%" == "true" (
   set "ARCHIVES=%CODEX_ARCHIVE_PREFIX% %CIRDL_ARCHIVE_PREFIX%"
@@ -139,7 +167,13 @@ for %%f in (%ARCHIVES%) do (
 
   for %%f in (!ARCHIVE_NAME! !ARCHIVE_NAME!.sha256) do (
     set ARCHIVE=%%f
-    set DOWNLOAD_URL=!BASE_URL!/releases/download/!VERSION!/!ARCHIVE!
+    echo %BASE_URL% | find /i "https://github.com/" >nul
+    if !errorlevel! equ 0 (
+      set DOWNLOAD_URL=%BASE_URL%/releases/download/%VERSION%/!ARCHIVE!
+    ) else (
+      set DOWNLOAD_URL=%BASE_URL%/%VERSION%/!ARCHIVE!
+    )
+
     set message="Downloading !ARCHIVE!"
     call :show_progress !message!
     @rem we can't rely on http_code - https://github.com/curl/curl/issues/13845
@@ -169,6 +203,7 @@ for %%f in (%ARCHIVES%) do (
 :: Create directory
 set message="Creating installation directory %INSTALL_DIR%"
 call :show_progress !message!
+echo "INSTALL_DIR - %INSTALL_DIR%"
 if not exist %INSTALL_DIR% mkdir %INSTALL_DIR%
 if not !errorlevel! == 0 (
   call :show_fail !message! "Failed to create %INSTALL_DIR%"
@@ -230,6 +265,6 @@ if not %errorlevel% equ 0 (
   @rem setx PATH "%PATH%%INSTALL_DIR;" >nul 2>&1
 )
 
-:: Delete
+:: Self delete
 :delete
 goto 2>nul & del "%~f0"

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ CODEX_BINARY_PREFIX="codex"
 CIRDL_BINARY_PREFIX="cirdl"
 WINDOWS_LIBS=${WINDOWS_LIBS:-false}
 WINDOWS_LIBS_LIST="libstdc++-6.dll libgomp-1.dll libgcc_s_seh-1.dll libwinpthread-1.dll"
-BASE_URL="https://github.com/codex-storage/nim-codex"
+BASE_URL=${BASE_URL:-https://github.com/codex-storage/nim-codex}
 API_BASE_URL="https://api.github.com/repos/codex-storage/nim-codex"
 TEMP_DIR="${TEMP_DIR:-.}"
 PROGRESS_MARK="\033[0;36m\u2022\033[0m"
@@ -32,11 +32,12 @@ if [[ $1 == *"h"* ]] ; then
     ${COMMAND} | bash -s help
 
   \e[33mOptions:\e[0m
-    - help                       - show this help
-    - VERSION=0.1.7              - codex and cird version to install
-    - CIRDL=true                 - install cirdl
-    - INSTALL_DIR=/usr/local/bin - directory to install binaries
-    - WINDOWS_LIBS=true          - download and install archive with libs for windows
+    - help                           - show this help
+    - VERSION=0.1.7                  - codex and cird version to install
+    - CIRDL=true                     - install cirdl
+    - INSTALL_DIR=/usr/local/bin     - directory to install binaries
+    - WINDOWS_LIBS=true              - download and install archive with libs for windows
+    - BASE_URL=http://localhost:8080 - custom base URL for binaries downloading
   "
   exit 0
 fi
@@ -126,10 +127,14 @@ fi
 
 # Download
 for ARCHIVE in "${ARCHIVES[@]}"; do
-  FILE_NAME="${ARCHIVE}-${ARCHIVE_SUFFIX}"
+  ARCHIVE_NAME="${ARCHIVE}-${ARCHIVE_SUFFIX}"
 
-  for FILE in "${FILE_NAME}" "${FILE_NAME}.sha256"; do
-    DOWNLOAD_URL="${BASE_URL}/releases/download/${VERSION}/${FILE}"
+  for FILE in "${ARCHIVE_NAME}" "${ARCHIVE_NAME}.sha256"; do
+    if [[ "${BASE_URL}" == *"https://github.com/"* ]]; then
+      DOWNLOAD_URL="${BASE_URL}/releases/download/${VERSION}/${FILE}"
+    else
+      DOWNLOAD_URL="${BASE_URL}/${VERSION}/${FILE}"
+    fi
 
     message="Downloading ${FILE}"
     show_progress "${message}"
@@ -140,41 +145,41 @@ done
 
 # Checksum
 for ARCHIVE in "${ARCHIVES[@]}"; do
-  FILE_NAME="${ARCHIVE}-${ARCHIVE_SUFFIX}"
-  message="Verifying checksum for ${FILE_NAME}"
+  ARCHIVE_NAME="${ARCHIVE}-${ARCHIVE_SUFFIX}"
+  message="Verifying checksum for ${ARCHIVE_NAME}"
   show_progress "${message}"
 
-  EXPECTED_SHA256=$(cat "${TEMP_DIR}/${FILE_NAME}.sha256" | cut -d' ' -f1)
+  EXPECTED_SHA256=$(cat "${TEMP_DIR}/${ARCHIVE_NAME}.sha256" | cut -d' ' -f1)
   if [[ "${OS}" == "darwin" ]]; then
-    ACTUAL_SHA256=$(shasum -a 256 "${TEMP_DIR}/${FILE_NAME}" | cut -d ' ' -f 1)
+    ACTUAL_SHA256=$(shasum -a 256 "${TEMP_DIR}/${ARCHIVE_NAME}" | cut -d ' ' -f 1)
   else
-    ACTUAL_SHA256=$(sha256sum "${TEMP_DIR}/${FILE_NAME}" | cut -d ' ' -f 1)
+    ACTUAL_SHA256=$(sha256sum "${TEMP_DIR}/${ARCHIVE_NAME}" | cut -d ' ' -f 1)
   fi
 
   if [[ "$ACTUAL_SHA256" == "$EXPECTED_SHA256" ]]; then
     show_pass "${message}"
   else
-    show_fail "${message}" "Checksum verification failed for ${FILE_NAME}. Expected: $EXPECTED_SHA256, Got: $ACTUAL_SHA256"
+    show_fail "${message}" "Checksum verification failed for ${ARCHIVE_NAME}. Expected: $EXPECTED_SHA256, Got: $ACTUAL_SHA256"
   fi
 done
 
 # Extract
 for ARCHIVE in "${ARCHIVES[@]}"; do
-  FILE_NAME="${ARCHIVE}-${ARCHIVE_SUFFIX}"
+  ARCHIVE_NAME="${ARCHIVE}-${ARCHIVE_SUFFIX}"
 
-  message="Extracting ${FILE_NAME}"
+  message="Extracting ${ARCHIVE_NAME}"
   show_progress "${message}"
 
   if [[ "${OS}" == "windows" ]]; then
     if unzip -v &> /dev/null; then
-      unzip -q -o "${TEMP_DIR}/${FILE_NAME}" -d "${TEMP_DIR}"
+      unzip -q -o "${TEMP_DIR}/${ARCHIVE_NAME}" -d "${TEMP_DIR}"
       [[ $? -ne 0 ]] && show_fail "${message}"
     else
-      C:/Windows/system32/tar.exe -xzf "${TEMP_DIR}/${FILE_NAME}" -C "${TEMP_DIR}"
+      C:/Windows/system32/tar.exe -xzf "${TEMP_DIR}/${ARCHIVE_NAME}" -C "${TEMP_DIR}"
       [[ $? -ne 0 ]] && show_fail "${message}"
     fi
   else
-    tar -xzf "${TEMP_DIR}/${FILE_NAME}" -C "${TEMP_DIR}"
+    tar -xzf "${TEMP_DIR}/${ARCHIVE_NAME}" -C "${TEMP_DIR}"
     [[ $? -ne 0 ]] && show_fail "${message}"
   fi
   show_pass "${message}"
@@ -182,15 +187,15 @@ done
 
 # Install
 for BINARY in "${BINARIES[@]}"; do
-  FILE_NAME="${BINARY}-${BINARY_SUFFIX}"
+  BINARY_NAME="${BINARY}-${BINARY_SUFFIX}"
   INSTALL_PATH="${INSTALL_DIR}/${BINARY}"
 
   # Install
-  message="Installing ${FILE_NAME} to ${INSTALL_PATH}"
+  message="Installing ${BINARY_NAME} to ${INSTALL_PATH}"
   show_progress "${message}"
-  if ! (mkdir -p "${INSTALL_DIR}" && install -m 755 "${TEMP_DIR}/${FILE_NAME}" "${INSTALL_PATH}") 2> /dev/null; then
+  if ! (mkdir -p "${INSTALL_DIR}" && install -m 755 "${TEMP_DIR}/${BINARY_NAME}" "${INSTALL_PATH}") 2> /dev/null; then
     $(sudo -n true 2>/dev/null) || TRIM=2
-    sudo mkdir -p "${INSTALL_DIR}" && sudo install -m 755 "${TEMP_DIR}/${FILE_NAME}" "${INSTALL_PATH}"
+    sudo mkdir -p "${INSTALL_DIR}" && sudo install -m 755 "${TEMP_DIR}/${BINARY_NAME}" "${INSTALL_PATH}"
     [[ $? -ne 0 ]] && show_fail "${message}"
   fi
   show_pass "${message}"
@@ -210,8 +215,8 @@ fi
 message="Cleanup"
 show_progress "${message}"
 for BINARY in "${BINARIES[@]}"; do
-  FILE_NAME="${BINARY}-${BINARY_SUFFIX}"
-  rm -f "${TEMP_DIR}/${FILE_NAME}"*
+  ARCHIVE_NAME="${BINARY}-${BINARY_SUFFIX}"
+  rm -f "${TEMP_DIR}/${ARCHIVE_NAME}"*
   [[ $? -ne 0 ]] && show_fail "${message}"
 done
 show_pass "${message}"

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ set -e
 
 # Variables
 VERSION=${VERSION:-latest}
-INSTALL_CIRDL=${INSTALL_CIRDL:-false}
+CIRDL=${CIRDL:-false}
 INSTALL_DIR=${INSTALL_DIR:-/usr/local/bin}
 CODEX_ARCHIVE_PREFIX="codex"
 CIRDL_ARCHIVE_PREFIX="cirdl"
@@ -28,13 +28,13 @@ if [[ $1 == *"h"* ]] ; then
   \e[33mUsage:\e[0m
     ${COMMAND} | bash
     ${COMMAND} | VERSION=0.1.7 bash
-    ${COMMAND} | VERSION=0.1.7 INSTALL_CIRDL=true bash
+    ${COMMAND} | VERSION=0.1.7 CIRDL=true bash
     ${COMMAND} | bash -s help
 
   \e[33mOptions:\e[0m
     - help                       - show this help
     - VERSION=0.1.7              - codex and cird version to install
-    - INSTALL_CIRDL=true         - install cirdl
+    - CIRDL=true                 - install cirdl
     - INSTALL_DIR=/usr/local/bin - directory to install binaries
     - WINDOWS_LIBS=true          - download and install archive with libs for windows
   "
@@ -77,8 +77,8 @@ show_progress "${message}"
 # Archives and binaries
 message="Compute archives and binaries names"
 show_progress "${message}"
-[[ "${INSTALL_CIRDL}" == "true" ]] && ARCHIVES=("${CODEX_ARCHIVE_PREFIX}" "${CIRDL_ARCHIVE_PREFIX}") || ARCHIVES=("${CODEX_ARCHIVE_PREFIX}")
-[[ "${INSTALL_CIRDL}" == "true" ]] && BINARIES=("${CODEX_BINARY_PREFIX}" "${CIRDL_BINARY_PREFIX}") || BINARIES=("${CODEX_BINARY_PREFIX}")
+[[ "${CIRDL}" == "true" ]] && ARCHIVES=("${CODEX_ARCHIVE_PREFIX}" "${CIRDL_ARCHIVE_PREFIX}") || ARCHIVES=("${CODEX_ARCHIVE_PREFIX}")
+[[ "${CIRDL}" == "true" ]] && BINARIES=("${CODEX_BINARY_PREFIX}" "${CIRDL_BINARY_PREFIX}") || BINARIES=("${CODEX_BINARY_PREFIX}")
 show_pass "${message}"
 
 # Get the current OS


### PR DESCRIPTION
PR contains some small changes for installation script
 - Variable `INSTALL_CIRDL` was renamed to `CIRDL` (save the World)
 - Readme and index files updated to use renamed variable
 - Added `BASE_URL` variable to be able to download files from a custom URL - useful for local download at workshops
 - Help updated to show `BASE_URL` variable
 - Refactored variables definition on Windows and move trailing spaces removal to the start