### PR TITLE
Add site subfolders support for CI

### DIFF
--- a/.github/workflows/get-codex.yml
+++ b/.github/workflows/get-codex.yml
@@ -34,13 +34,15 @@ jobs:
       - name: Prepare file
         run: |
           mkdir ${{ env.folder }}
-          find . -type f \
+          find . \
             -maxdepth 1 \
-            -name "*.*" \
+            -mindepth 1 \
+            ! -name site \
+            ! -name CNAME \
             ! -name '*.md' \
             ! -name ".git*" \
             ! -name "LICENSE*" \
-            -exec cp {} ${{ env.folder }} \;
+            -exec cp -r {} ${{ env.folder }} \;
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION

PR updates CI and add subfolders support for [get.codex.storage](https://get.codex.storage) site. This is the first step for wrappers support for different networks.

In that way, now we can
 1. Create a subfolder - `testnet`
 2. Add wrapper scripts like following - `testnet/install.cmd`
    ```shell
    # Codex Testnet

    # Install Codex
    curl -s https://get.codex.storage/install.sh | CIRDL=true bash
    ```

 3. And more files like following
    ```
    └── testnet
        ├── README.md
        ├── generate.cmd
        ├── generate.sh
        ├── index.html
        ├── install.cmd
        ├── install.sh
        ├── run.cmd
        └── run.sh
    ```

 4. CI will deploy them and we can access them via [get.codex.storage/testnet](https://get.codex.storage/testnet)
    ```shell
    # Codex Testnet
    curl -s https://get.codex.storage/testnet/install.sh
    curl -s https://get.codex.storage/testnet/generate.sh
    curl -s https://get.codex.storage/testnet/run.sh
    ```
